### PR TITLE
Fix and improve Japanese translation.

### DIFF
--- a/ja/menu.json
+++ b/ja/menu.json
@@ -50,7 +50,7 @@
         "vim-mode": "VIM モードをトグル",
         "toggle-toc": "目次をトグル",
         "enter-full-screen": "フルスクリーン",
-        "enter-presentation": "Presentation Mode",
+        "enter-presentation": "プレゼンテーション",
         "editor": {
             "theme": "エディタ テーマ...",
             "theme-user": "エディタ ユーザ テーマ..."
@@ -67,8 +67,8 @@
         "filename": "ファイル名",
         "copy-html": "HTML をコピー",
         "header": "見出し",
-        "bold": "強い強調",
-        "italic": "強調",
+        "bold": "強調",
+        "italic": "斜体",
         "inline-code": "インラインコード",
         "image": "画像",
         "link": "リンク",
@@ -83,7 +83,7 @@
         "task": "Tasklist",
         "embed": "埋め込み",
         "footnotes": "Footnotes",
-        "footnotes-ref": "Footnotes Reference",
+        "footnotes-ref": "Footnotes リファレンス",
         "toc": "目次",
         "table": "表",
         "comment": "コメント",

--- a/ja/menu.json
+++ b/ja/menu.json
@@ -36,7 +36,7 @@
         "mode-editor": "エディタ",
         "mode-viewer": "ビューワ",
         "toggle-live-view": "ライブビューをトグル",
-        "toggle-markdown-help": "Toggle Markdown Syntax Helper",
+        "toggle-markdown-help": "Markdown Syntax Helperをトグル",
         "toggle-line-number": "行番号をトグル",
         "live-view-width-plus-5": "ライブビューの幅を +5%",
         "live-view-width-minus-5": "ライブビューの幅を -5%",


### PR DESCRIPTION
## Overview
I would fixed and improved Japanese traslation as blow.

### Fix

|before|after|
|:--|:--|
|強調       |斜体|
|強い強調  |強調|

### Improve

|before|after|
|:--|:--|
|Toggle Markdown Syntax Helper|Markdown Syntax Helperをトグル|
|Presentation Mode|プレゼンテーション|
|Footnotes Reference|Footnotes リファレンス|